### PR TITLE
Implement ChaxAI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Python
+__pycache__/
+*.py[cod]
+*.env
+
+# Vector store
+backend/vectorstore/
+
+# Node
+node_modules/
+dist/
+
+# Others
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,74 +1,36 @@
-````markdown
 # ChaxAI
 
-**ChaxAI** is an open-source, self-hosted AI assistant that allows users to chat with their own documents. It enables contextual Q&A over PDFs, markdown files, or structured knowledge bases by combining vector search with powerful LLMs like GPT-4.
+ChaxAI is a self‑hosted assistant that answers questions using the contents of your documents. It combines FastAPI, LangChain, and OpenAI with a FAISS vector store. A lightweight React interface enables chatting with the backend. The project is designed for easy local deployment and extension.
 
-> 🧠 Chat with your knowledge base — locally, securely, and intelligently.
+## Features
 
----
+- Parse PDF, Markdown, and text files
+- Create a FAISS vector index locally
+- Ask questions through a REST API with source citations
+- React + Tailwind chat UI with light/dark mode
+- Health check and document listing endpoints
 
-## ✨ Features
+## Getting Started
 
-- 🧾 **Document Understanding**  
-  Parse and embed PDFs, Markdown, and plain text files.
+### 1. Ingest Documents
 
-- 🧠 **GPT-4 / OpenAI Integration**  
-  Natural language responses backed by large language models.
-
-- ⚡ **Fast Vector Search**  
-  FAISS-powered embedding search for instant relevant context.
-
-- 🔒 **Fully Self-Hosted**  
-  No third-party storage — your data stays within your environment.
-
-- 🧩 **Modular Architecture**  
-  Easily swap in local models, different vector databases, or file types.
-
-- 🛠 **Workflow Automation (WIP)**  
-  Define rule-based triggers and automated responses for repetitive tasks.
-
----
-
-## 🧰 Tech Stack
-
-- **Frontend**: React + TailwindCSS *(optional)*
-- **Backend**: FastAPI (Python)
-- **Vector Store**: FAISS (can swap with ChromaDB, Weaviate, etc.)
-- **Embeddings**: OpenAI, HuggingFace Transformers
-- **LLM Provider**: OpenAI GPT-4 (or compatible APIs)
-
----
-
-## 🚀 Getting Started
-
-### 1. Clone the repository
+Place your files in `backend/docs/` and run:
 
 ```bash
-git clone https://github.com/Nickalus12/ChaxAI.git
-cd ChaxAI
-````
-
-### 2. Install Python dependencies
-
-```bash
+cd backend
+cp .env.example .env  # add your OpenAI key
+# optionally set VECTORSTORE_DIR if you wish to store embeddings elsewhere
 pip install -r requirements.txt
+python app/ingest.py
 ```
 
-### 3. Ingest your documents
-
-```bash
-python ingest.py --source ./docs --index ./vectorstore
-```
-
-This will parse documents and build a searchable vector index.
-
-### 4. Start the backend server
+### 2. Start the Backend
 
 ```bash
 uvicorn app.main:app --reload
 ```
 
-### 5. (Optional) Start the frontend
+### 3. Start the Frontend
 
 ```bash
 cd frontend
@@ -76,86 +38,22 @@ npm install
 npm run dev
 ```
 
----
+Open <http://localhost:3000> and start asking questions.
 
-## 🧪 Example API Usage
+### API Endpoints
 
-### Request
+The backend exposes a few endpoints:
 
-```http
-POST /ask
-Content-Type: application/json
+| Method | Path        | Description                    |
+| ------ | ----------- | ------------------------------ |
+| `GET`  | `/health`   | Returns `{"status": "ok"}`      |
+| `GET`  | `/documents`| List document sources in the vector store |
+| `POST` | `/ask`      | Ask a question using JSON `{ "question": "..." }` |
 
-{
-  "question": "What is the refund policy?",
-  "context": ["knowledge_base"]
-}
-```
+## Contributing
 
-### Response
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-```json
-{
-  "answer": "Our refund policy allows returns within 30 days of purchase with a valid receipt."
-}
-```
+## License
 
----
-
-## 📌 Roadmap
-
-* [x] Document ingestion via PDF/Markdown
-* [x] GPT-4 integration via LangChain
-* [x] FAISS vector store support
-* [ ] Web-based UI for file upload
-* [ ] Rule-based automations ("If user mentions X, do Y")
-* [ ] User authentication
-* [ ] Docker + Helm charts for deployment
-* [ ] Switchable LLM support (LLaMA, Mistral, etc.)
-
----
-
-## 🤝 Contributing
-
-We welcome contributions from the community!
-
-To get started:
-
-1. Fork this repository
-2. Create a new branch: `git checkout -b feature/your-feature-name`
-3. Make your changes
-4. Commit and push: `git commit -am 'Add new feature' && git push origin feature/your-feature-name`
-5. Open a Pull Request
-
-For more details, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
----
-
-## 📄 License
-
-This project is licensed under the [MIT License](LICENSE).
-
-© 2025 [Nickalus Brewer](https://github.com/Nickalus12) — You are free to use, modify, and distribute with attribution.
-
----
-
-## 🙏 Credits
-
-Built with:
-
-* [LangChain](https://github.com/langchain-ai/langchain)
-* [FAISS](https://github.com/facebookresearch/faiss)
-* [OpenAI API](https://platform.openai.com/)
-* [FastAPI](https://github.com/tiangolo/fastapi)
-* Inspired by the design of Rasa, Chatbot UI, and other great open-source assistants.
-
----
-
-## 🌐 Stay Updated
-
-Star the project and follow [@Nickalus12](https://github.com/Nickalus12) for updates and new AI-powered tools.
-
-```
-
-Let me know if you want a `CONTRIBUTING.md`, `LICENSE`, or `requirements.txt` scaffold next.
-```
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key_here
+VECTORSTORE_DIR=vectorstore

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# ChaxAI backend package

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = BASE_DIR / '.env'
+
+load_dotenv(dotenv_path=ENV_PATH)
+
+VECTOR_DIR = os.getenv('VECTORSTORE_DIR', str(BASE_DIR / 'vectorstore'))
+
+
+def get_openai_key() -> str:
+    """Retrieve the OpenAI API key from the environment."""
+    key = os.getenv('OPENAI_API_KEY')
+    if not key:
+        raise RuntimeError('OPENAI_API_KEY is not set')
+    return key

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -1,0 +1,58 @@
+"""Document ingestion script."""
+
+import os
+from pathlib import Path
+from typing import List
+
+from langchain_openai import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import FAISS
+from langchain_community.document_loaders import (
+    TextLoader,
+    PyPDFLoader,
+    UnstructuredMarkdownLoader,
+)
+
+from .config import VECTOR_DIR, BASE_DIR, get_openai_key
+
+DOCS_DIR = BASE_DIR / "docs"
+
+
+def load_documents(source_dir: str) -> List[str]:
+    """Recursively load documents from ``source_dir``."""
+    docs = []
+    for path in Path(source_dir).rglob("*"):
+        suffix = path.suffix.lower()
+        if suffix == ".pdf":
+            loader = PyPDFLoader(str(path))
+        elif suffix == ".md":
+            loader = UnstructuredMarkdownLoader(str(path))
+        elif suffix in {".txt", ".text"}:
+            loader = TextLoader(str(path))
+        else:
+            continue
+        docs.extend(loader.load())
+    return docs
+
+
+def main():
+    """Build or update the FAISS vector store from documents."""
+    if not DOCS_DIR.is_dir():
+        raise RuntimeError(f"Docs directory '{DOCS_DIR}' not found")
+
+    embeddings = OpenAIEmbeddings(openai_api_key=get_openai_key())
+    documents = load_documents(str(DOCS_DIR))
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+    split_docs = splitter.split_documents(documents)
+
+    if os.path.isdir(VECTOR_DIR):
+        store = FAISS.load_local(VECTOR_DIR, embeddings)
+        store.add_documents(split_docs)
+    else:
+        store = FAISS.from_documents(split_docs, embeddings)
+    store.save_local(VECTOR_DIR)
+    print(f"Saved vector store to {VECTOR_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .schemas import Question, Answer
+from .vector import ask_question, list_documents
+
+app = FastAPI(title="ChaxAI Backend")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/documents", response_model=list[str])
+def documents() -> list[str]:
+    return list_documents()
+
+
+@app.post("/ask", response_model=Answer)
+def ask(payload: Question) -> Answer:
+    try:
+        return ask_question(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class Question(BaseModel):
+    question: str
+
+
+class Answer(BaseModel):
+    answer: str
+    sources: List[str]

--- a/backend/app/vector.py
+++ b/backend/app/vector.py
@@ -1,0 +1,39 @@
+import os
+from functools import lru_cache
+from typing import List
+from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+from langchain_community.vectorstores import FAISS
+from langchain.chains.question_answering import load_qa_chain
+from .config import VECTOR_DIR, get_openai_key
+from .schemas import Question, Answer
+
+
+@lru_cache(maxsize=1)
+def get_embeddings() -> OpenAIEmbeddings:
+    return OpenAIEmbeddings(openai_api_key=get_openai_key())
+
+
+@lru_cache(maxsize=1)
+def get_vectorstore() -> FAISS:
+    if not os.path.isdir(VECTOR_DIR):
+        raise RuntimeError(
+            f"Vector store not found in '{VECTOR_DIR}'. Run ingest.py first."
+        )
+    return FAISS.load_local(VECTOR_DIR, get_embeddings())
+
+
+def ask_question(payload: Question) -> Answer:
+    if not payload.question:
+        raise ValueError("Question cannot be empty")
+    store = get_vectorstore()
+    docs = store.similarity_search(payload.question, k=4)
+    llm = ChatOpenAI(openai_api_key=get_openai_key())
+    chain = load_qa_chain(llm, chain_type="stuff")
+    answer_text = chain.run(input_documents=docs, question=payload.question)
+    sources = [doc.metadata.get("source", "") for doc in docs]
+    return Answer(answer=answer_text, sources=sources)
+
+
+def list_documents() -> List[str]:
+    store = get_vectorstore()
+    return [meta.get("source", "") for meta in store.docstore._dict.values()]

--- a/backend/docs/sample.txt
+++ b/backend/docs/sample.txt
@@ -1,0 +1,2 @@
+Sample documentation for ChaxAI.
+Another line for testing vector search.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+langchain
+langchain-community
+langchain-openai
+faiss-cpu
+unstructured
+python-dotenv
+PyPDF2

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ChaxAI</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-100 dark:bg-gray-800">
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "chaxai-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.4.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import axios from 'axios'
+
+function App() {
+  const [question, setQuestion] = useState('')
+  const [messages, setMessages] = useState([])
+  const [theme, setTheme] = useState('light')
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light')
+    document.documentElement.classList.toggle('dark')
+  }
+
+  const submitQuestion = async (e) => {
+    e.preventDefault()
+    if (!question) return
+    try {
+      const { data } = await axios.post('http://localhost:8000/ask', { question })
+      setMessages([...messages, { question, answer: data.answer, sources: data.sources }])
+      setQuestion('')
+    } catch (err) {
+      console.error(err)
+      setMessages([...messages, { question, answer: 'Error fetching answer', sources: [] }])
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4 gap-4">
+      <button onClick={toggleTheme} className="self-end px-2 py-1 border rounded">
+        {theme === 'light' ? 'Dark' : 'Light'} Mode
+      </button>
+      <h1 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">
+        ChaxAI
+      </h1>
+      <form onSubmit={submitQuestion} className="w-full max-w-xl flex flex-col gap-2">
+        <input
+          className="border rounded p-2 dark:bg-gray-700 dark:text-white"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask a question"
+        />
+        <button className="bg-blue-500 text-white p-2 rounded" type="submit">
+          Ask
+        </button>
+      </form>
+      <div className="w-full max-w-xl flex flex-col gap-4">
+        {messages.map((m, idx) => (
+          <div key={idx} className="bg-white dark:bg-gray-700 p-4 rounded shadow">
+            <p className="font-semibold">Q: {m.question}</p>
+            <p className="mt-2">A: {m.answer}</p>
+            {m.sources && m.sources.length > 0 && (
+              <ul className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                {m.sources.map((s, i) => (
+                  <li key={i}>{s}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+})


### PR DESCRIPTION
## Summary
- create backend FastAPI service with `/ask` route
- add document ingestion script using FAISS and LangChain
- provide sample docs and environment template
- scaffold React frontend with Tailwind and theme toggle
- refine backend setup and docs
- add vector store utilities and document listing
- show answer sources in chat UI

## Testing
- `python -m py_compile backend/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684226d31604832cb86d31c6426fa0ab